### PR TITLE
Make sure we always build with HDF5 nompi variant

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 37997f189702b4705f69b2db5f64cef31cfa9ab9eb151dfc0457c72dba422345
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:
@@ -29,6 +29,9 @@ requirements:
     - numpy
     - libboost-devel
     - hdf5
+    # Ensure that we build with nompi variant
+    # it provides downstream packages with the most flexibility
+    - hdf5 =*=nompi*
   run:
     - python
     - hdf5


### PR DESCRIPTION
Fail the build if HDF5's nompi variant is not
available. This makes our packages maximally useful to downstream, since they don't then require a specific MPI implementation. See also conda-forge/opencv-feedstock#468, conda-forge/hdf5-feedstock#258.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
